### PR TITLE
Fix race condition in eureka test case

### DIFF
--- a/eureka/eureka_test.go
+++ b/eureka/eureka_test.go
@@ -15,10 +15,10 @@ func TestDiscovery(t *testing.T) {
 	fmt.Println("eureka_test start")
 	listener := make(chan gotocol.Message)
 	edda.Logchan = make(chan gotocol.Message, 10) // buffered channel
-	go edda.Start("test.edda")
 	archaius.Conf.Msglog = true
 	archaius.Conf.GraphjsonFile = "test"
 	archaius.Conf.GraphmlFile = "test"
+	go edda.Start("test.edda")
 	eureka := make(chan gotocol.Message, 10)
 	go Start(eureka, "test.eureka")
 	// stack up a series of requests in the buffered channel


### PR DESCRIPTION
Ran the race detector on your tests and found the race condition below. The globally accessible and mutable archaius package Conf variable is dangerous when accessed by multiple goroutines.
`go test -race ./...`

```
eureka_test start
2015/04/20 22:09:32 test.edda: starting
2015/04/20 22:09:32 test.eureka: starting
==================
WARNING: DATA RACE
Read by goroutine 9:
  github.com/adrianco/spigo/edda.Start()
      /Users/vasko/gocode/src/github.com/adrianco/spigo/edda/edda.go:35 +0x314

Previous write by goroutine 8:
  github.com/adrianco/spigo/eureka.TestDiscovery()
      /Users/vasko/gocode/src/github.com/adrianco/spigo/eureka/eureka_test.go:21 +0x232
  testing.tRunner()
      /Users/vasko/code/go/src/testing/testing.go:452 +0xfc

Goroutine 9 (running) created at:
  github.com/adrianco/spigo/eureka.TestDiscovery()
      /Users/vasko/gocode/src/github.com/adrianco/spigo/eureka/eureka_test.go:18 +0x1cd
  testing.tRunner()
      /Users/vasko/code/go/src/testing/testing.go:452 +0xfc

Goroutine 8 (running) created at:
  testing.RunTests()
      /Users/vasko/code/go/src/testing/testing.go:560 +0xc9b
  testing.(*M).Run()
      /Users/vasko/code/go/src/testing/testing.go:490 +0xe7
  main.main()
      github.com/adrianco/spigo/eureka/_test/_testmain.go:54 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  github.com/adrianco/spigo/edda.Start()
      /Users/vasko/gocode/src/github.com/adrianco/spigo/edda/edda.go:38 +0x34d

Previous write by goroutine 8:
2015/04/20 22:09:32 test.eureka(backlog 4): gotocol: 531.226µs Hello test0 test
  github.com/adrianco/spigo/eureka.TestDiscovery()
      /Users/vasko/gocode/src/github.com/adrianco/spigo/eureka/eureka_test.go:20 +0x204
  testing.tRunner()
      /Users/vasko/code/go/src/testing/testing.go:452 +0xfc

Goroutine 9 (running) created at:
  github.com/adrianco/spigo/eureka.TestDiscovery()
      /Users/vasko/gocode/src/github.com/adrianco/spigo/eureka/eureka_test.go:18 +0x1cd
  testing.tRunner()
      /Users/vasko/code/go/src/testing/testing.go:452 +0xfc

Goroutine 8 (running) created at:
  testing.RunTests()
      /Users/vasko/code/go/src/testing/testing.go:560 +0xc9b
  testing.(*M).Run()
      /Users/vasko/code/go/src/testing/testing.go:490 +0xe7
  main.main()
      github.com/adrianco/spigo/eureka/_test/_testmain.go:54 +0x28c
==================
```
