### PR TITLE
Fix broken npm scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-script: cd ui && npm install && npm run build:prod && cd ..
+script: cd ui && npm install && npm run build && cd ..
 deploy:
   provider: divshot
   environment:

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,7 +4,7 @@
 
 > You must have [Node.js](http://nodejs.org) installed to build the UI.
 
-To build the UI `cd` in to `ui` directory and run `npm install`. Next run `gulp dev`.
+To build the UI `cd` in to `ui` directory and run `npm install`. Next run `npm run dev`.
 You should now have a local instance running on port `8000`.
 
 ___

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,9 +4,10 @@
   "description": "spigo =====",
   "main": "",
   "scripts": {
-    "test": "gulp test",
-    "lint": "gulp lint",
-    "build:prod": "gulp build-prod"
+    "test": "node_modules/.bin/gulp test",
+    "lint": "node_modules/.bin/gulp lint",
+    "dev": "node_modules/.bin/gulp dev",
+    "build": "node_modules/.bin/gulp build-prod"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
fixed readme for UI, updated npm scripts to point to local version of gulp

there should no longer be a need to have gulp installed globally, running `npm run dev` will build local version of app and start server on port `8000`