### PR TITLE
Allow varible number of Regions and Zones instead of only 3

### DIFF
--- a/actors/denominator/denominator.go
+++ b/actors/denominator/denominator.go
@@ -18,14 +18,14 @@ import (
 // Start the denominator, all configuration and state is sent via messages
 func Start(listener chan gotocol.Message) {
 	microservices := ribbon.MakeRouter()
-	dependencies := make(map[string]time.Time)                               // dependent services and time last updated
-	var parent chan gotocol.Message                                          // remember how to talk back to creator
-	var name string                                                          // remember my name
-	nethist := collect.NewHist("")                                           // don't know name yet - message network latency
-	resphist := collect.NewHist("")                                          // response time history
-	servhist := collect.NewHist("")                                          // service time history
-	rthist := collect.NewHist("")                                            // round trip history
-	eureka := make(map[string]chan gotocol.Message, 3*archaius.Conf.Regions) // service registry per zone and region
+	dependencies := make(map[string]time.Time)                                                          // dependent services and time last updated
+	var parent chan gotocol.Message                                                                     // remember how to talk back to creator
+	var name string                                                                                     // remember my name
+	nethist := collect.NewHist("")                                                                      // don't know name yet - message network latency
+	resphist := collect.NewHist("")                                                                     // response time history
+	servhist := collect.NewHist("")                                                                     // service time history
+	rthist := collect.NewHist("")                                                                       // round trip history
+	eureka := make(map[string]chan gotocol.Message, len(archaius.Conf.ZoneNames)*archaius.Conf.Regions) // service registry per zone and region
 	var chatrate time.Duration
 	ep, _ := time.ParseDuration(archaius.Conf.EurekaPoll)
 	eurekaTicker := time.NewTicker(ep)

--- a/actors/elb/elb.go
+++ b/actors/elb/elb.go
@@ -15,11 +15,11 @@ import (
 // Start the elb, all configuration and state is sent via messages
 func Start(listener chan gotocol.Message) {
 	microservices := ribbon.MakeRouter()
-	dependencies := make(map[string]time.Time)         // dependent services and time last updated
-	var parent chan gotocol.Message                    // remember how to talk back to creator
-	requestor := make(map[string]gotocol.Routetype)    // remember where requests came from when responding
-	var name string                                    // remember my name
-	eureka := make(map[string]chan gotocol.Message, 3) // service registry per zone
+	dependencies := make(map[string]time.Time)                                    // dependent services and time last updated
+	var parent chan gotocol.Message                                               // remember how to talk back to creator
+	requestor := make(map[string]gotocol.Routetype)                               // remember where requests came from when responding
+	var name string                                                               // remember my name
+	eureka := make(map[string]chan gotocol.Message, len(archaius.Conf.ZoneNames)) // service registry per zone
 	ep, _ := time.ParseDuration(archaius.Conf.EurekaPoll)
 	eurekaTicker := time.NewTicker(ep)
 	hist := collect.NewHist("")

--- a/actors/priamCassandra/priamCassandra.go
+++ b/actors/priamCassandra/priamCassandra.go
@@ -93,9 +93,9 @@ func Start(listener chan gotocol.Message) {
 	dependencies := make(map[string]time.Time) // dependent services and time last updated
 	store := make(map[string]string, 4)        // key value store
 	store["why?"] = "because..."
-	var parent chan gotocol.Message                                          // remember how to talk back to creator
-	var name string                                                          // remember my name
-	eureka := make(map[string]chan gotocol.Message, 3*archaius.Conf.Regions) // service registry per zone and region
+	var parent chan gotocol.Message                                                                     // remember how to talk back to creator
+	var name string                                                                                     // remember my name
+	eureka := make(map[string]chan gotocol.Message, len(archaius.Conf.ZoneNames)*archaius.Conf.Regions) // service registry per zone and region
 	hist := collect.NewHist("")
 	ep, _ := time.ParseDuration(archaius.Conf.EurekaPoll)
 	eurekaTicker := time.NewTicker(ep)

--- a/actors/store/store.go
+++ b/actors/store/store.go
@@ -21,9 +21,9 @@ func Start(listener chan gotocol.Message) {
 	dependencies := make(map[string]time.Time) // dependent services and time last updated
 	store := make(map[string]string, 4)        // key value store
 	store["why?"] = "because..."
-	var netflixoss chan gotocol.Message                // remember creator and how to talk back to incoming requests
-	var name string                                    // remember my name
-	eureka := make(map[string]chan gotocol.Message, 3) // service registry per zone
+	var netflixoss chan gotocol.Message                                           // remember creator and how to talk back to incoming requests
+	var name string                                                               // remember my name
+	eureka := make(map[string]chan gotocol.Message, len(archaius.Conf.ZoneNames)) // service registry per zone
 	hist := collect.NewHist("")
 	ep, _ := time.ParseDuration(archaius.Conf.EurekaPoll)
 	eurekaTicker := time.NewTicker(ep)

--- a/tooling/archaius/archaius.go
+++ b/tooling/archaius/archaius.go
@@ -20,7 +20,7 @@ type Configuration struct {
 
 	// Neo4jURL is pointed at a database instance to turn on GraphML logging
 	Neo4jURL string `json:"neo4jurl,omitempty"`
-	
+
 	// RunDuration is the time in seconds to let the microservices chat
 	RunDuration time.Duration `json:"runduration,omitempty"`
 
@@ -37,13 +37,13 @@ type Configuration struct {
 	Regions int `json:"regions,omitempty"`
 
 	// RegionNames is the default names of the regions
-	RegionNames [6]string `json:"regionnames,omitempty"`
+	RegionNames []string `json:"regionnames,omitempty"`
 
 	// IPRanges maps an IP address range to each region and zone
-	IPRanges [6][3]string `json:"ipranges,omitempty"`
+	IPRanges [][]string `json:"ipranges,omitempty"`
 
 	// ZoneNames is the default names of the zones
-	ZoneNames [3]string `json:"zonenames,omitempty"`
+	ZoneNames []string `json:"zonenames,omitempty"`
 
 	// Collect turns on Metrics collection
 	Collect bool `json:"collect,omitempty"`
@@ -62,14 +62,28 @@ type Configuration struct {
 }
 
 var Conf = Configuration{
-	RegionNames: [...]string{"us-east-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-southeast-1", "ap-southeast-2"},
-	ZoneNames:   [...]string{"zoneA", "zoneB", "zoneC"},
-	IPRanges: [...][3]string{[...]string{"54.198.", "54.221.", "50.19."}, // Virginia us-east-1 actual AWS IP/16 ranges
-		[...]string{"54.245.", "54.244.", "54.214."},  // Oregon us-west-2 actual AWS IP/16 ranges
-		[...]string{"54.247.", "54.246.", "54.288."},  // Ireland eu-west-1 actual AWS IP/16 ranges
-		[...]string{"54.93.", "54.28.", "54.78."},     // Frankfurt eu-central-1 actual AWS IP/16 ranges plus 54.78  stolen from Ireland
-		[...]string{"54.251.", "54.254.", "54.255."},  // Singapore ap-southeast-1 actual AWS IP/16 ranges
-		[...]string{"54.252.", "54.253.", "54.206."}}, // Australia ap-southeast-2 actual AWS IP/16 ranges
+	RegionNames: []string{"us-east-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-southeast-1", "ap-southeast-2"},
+	ZoneNames:   []string{"zoneA", "zoneB", "zoneC"},
+	IPRanges: [][]string{
+		[]string{"54.198.", "54.221.", "50.19."},  // Virginia us-east-1 actual AWS IP/16 ranges
+		[]string{"54.245.", "54.244.", "54.214."}, // Oregon us-west-2 actual AWS IP/16 ranges
+		[]string{"54.247.", "54.246.", "54.288."}, // Ireland eu-west-1 actual AWS IP/16 ranges
+		[]string{"54.93.", "54.28.", "54.78."},    // Frankfurt eu-central-1 actual AWS IP/16 ranges plus 54.78  stolen from Ireland
+		[]string{"54.251.", "54.254.", "54.255."}, // Singapore ap-southeast-1 actual AWS IP/16 ranges
+		[]string{"54.252.", "54.253.", "54.206."}, // Australia ap-southeast-2 actual AWS IP/16 ranges
+	},
+}
+
+// verify the sizes of arrays above are equal at runtime
+func init() {
+    if len(Conf.RegionNames) != len(Conf.IPRanges) {
+        panic(fmt.Sprintf("RegionNames count (%d) does not match IPRanges count (%d)", len(Conf.RegionNames), len(Conf.IPRanges)))
+    }
+    for i := range Conf.IPRanges {
+        if len(Conf.ZoneNames) != len(Conf.IPRanges[i]) {
+            panic(fmt.Sprintf("ZoneNames count (%d) does not match IPRanges[%d] count (%d)", len(Conf.ZoneNames), i, len(Conf.IPRanges[i])))
+        }
+    }
 }
 
 // find a value given a key

--- a/tooling/dhcp/dhcp.go
+++ b/tooling/dhcp/dhcp.go
@@ -8,11 +8,15 @@ import (
 )
 
 var (
-	allocated [6][3]int
+	allocated [][]int
 	mapped    map[string]string
 )
 
 func init() {
+	allocated = make([][]int, len(archaius.Conf.RegionNames))
+	for i := range allocated {
+		allocated[i] = make([]int, len(archaius.Conf.ZoneNames))
+	}
 	mapped = make(map[string]string, archaius.Conf.Population)
 }
 

--- a/tooling/names/names.go
+++ b/tooling/names/names.go
@@ -125,12 +125,11 @@ func Zone(name string) string {
 }
 
 // Return the other two zones, given one
-func OtherZones(name string, znames [3]string) [2]string {
-	var nz [2]string
-	for i, z := range znames {
-		if Zone(name) == z {
-			nz[0] = znames[(i+1)%3]
-			nz[1] = znames[(i+2)%3]
+func OtherZones(name string, znames []string) []string {
+	var nz []string
+	for _, z := range znames {
+		if Zone(name) != z {
+			nz = append(nz, z)
 		}
 	}
 	return nz


### PR DESCRIPTION
Allow varible number of Regions and Zones instead of only 3 (using slices instead of arrays)

I'm using Simianviz to model some internal traditional deployments that don't use AWS. I needed the ability to have a different number of Zones other than 3 in a Region. I didn't see a reason why Regions or Zones should be in a static array with assumptions about its size in other parts of the code, so I converted the arrays to slices and got their length dynamically where needed.

My next goal is to read in Regions and Zones dynamically from the Arch file so that a deployment can be modeled in different ways without changing the code.
