### PR TITLE
Read and write configs to a file in json_arch.  Remove omitempty from…

### DIFF
--- a/spigo.go
+++ b/spigo.go
@@ -42,7 +42,13 @@ func main() {
 	flag.IntVar(&cpucount, "cpus", runtime.NumCPU(), "Number of CPUs for Go runtime")
 	runtime.GOMAXPROCS(cpucount)
 	var cpuprofile = flag.String("cpuprofile", "", "Write cpu profile to file")
+	var confFile = flag.String("config", "", "Config file to read from json_arch/<config>_conf.json. This config overrides any other command-line arguments.")
+	var saveConfFile = flag.Bool("saveconfig", false, "Save config file to json_arch/<arch>_conf.json, using the arch name from -a.")
 	flag.Parse()
+
+	if *confFile != "" {
+		archaius.ReadConf(*confFile)
+	}
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
@@ -81,6 +87,11 @@ func main() {
 		edda.Logchan = make(chan gotocol.Message, 1000)
 	}
 	archaius.Conf.RunDuration = time.Duration(duration) * time.Second
+
+	if *saveConfFile {
+		archaius.WriteConf()
+	}
+
 	// start up the selected architecture
 	go edda.Start(archaius.Conf.Arch + ".edda") // start edda first
 	if reload {


### PR DESCRIPTION
Read and write configs to a file in json_arch.  Remove omitempty from Configuration so that all options are written to the conf file.

This allows RegionNames, ZoneNames, and IPRanges to be overridden at run-time.

Config file name is json_arch/<arch>_conf.json, using the arch name from -a

Usage:
$ ./spigo -saveconfig
2016/05/24 17:13:36 Saving config to json_arch/netflixoss_conf.json
2016/05/24 17:13:36 Loading architecture from json_arch/netflixoss_arch.json
...
2016/05/24 17:13:46 netflixoss.us-east-1.zoneB..eureka01...eureka.eureka: closing
2016/05/24 17:13:46 spigo: complete

$ ls -log json_arch/netflixoss_*
-rw-r--r--  1   1254 May 20 12:19 json_arch/netflixoss_arch.json
-rw-r--r--  1   1108 May 24 17:13 json_arch/netflixoss_conf.json

$ cat json_arch/netflixoss_conf.json 
{
    "arch": "netflixoss",
    "graphmlfile": "",
    "graphjsonfile": "",
    "neo4jurl": "",
    "runduration": 10000000000,
    "dunbar": 0,
    "population": 100,
    "msglog": false,
    "regions": 1,
    "regionnames": [
        "us-east-1",
        "us-west-2",
        "eu-west-1",
        "eu-central-1",
        "ap-southeast-1",
        "ap-southeast-2"
    ],
    "ipranges": [
        [
            "54.198.",
            "54.221.",
            "50.19."
        ],
        [
            "54.245.",
            "54.244.",
            "54.214."
        ],
        [
            "54.247.",
            "54.246.",
            "54.288."
        ],
        [
            "54.93.",
            "54.28.",
            "54.78."
        ],
        [
            "54.251.",
            "54.254.",
            "54.255."
        ],
        [
            "54.252.",
            "54.253.",
            "54.206."
        ]
    ],
    "zonenames": [
        "zoneA",
        "zoneB",
        "zoneC"
    ],
    "collect": false,
    "stopstep": 0,
    "eurekapoll": "1s",
    "filter": false,
    "keyvals": ""
}
