### PR TITLE
Update from ‘input’ to ‘expression’.

### DIFF
--- a/tooling/collect/collect.go
+++ b/tooling/collect/collect.go
@@ -102,7 +102,7 @@ func SaveAllGuesses(name string) {
 		})
 		g.Space.Graph.Guesstimates = append(g.Space.Graph.Guesstimates, Guesstimate{
 			Metric:          seq[row] + seq[col],
-			Input:           "",
+			Expression:      "",
 			GuesstimateType: "DATA",
 			Data:            data,
 		})


### PR DESCRIPTION
This pull request is to update spigo's generation of Guesstimate objects to use the new 'expression' field rather than the deprecated 'input' field. 

THIS PULL REQUEST CANNOT BE MERGED BEFORE THIS ONE FOR GOGUESSTIMATE:
https://github.com/adrianco/goguesstimate/pull/1
 